### PR TITLE
Provide HttpContext to getProxiedAddress Func

### DIFF
--- a/src/Test/UnitTests.cs
+++ b/src/Test/UnitTests.cs
@@ -54,7 +54,7 @@ namespace AspNetCore.Proxy.Tests
         {
             app.UseProxies();
 
-            app.UseProxy("api/comments/{postId}", (args) => {
+            app.UseProxy("api/comments/{postId}", (context, args) => {
                 return Task.FromResult($"https://jsonplaceholder.typicode.com/comments/{args["postId"]}");
             });
         }


### PR DESCRIPTION
There are cases where the HttpContext is required for building the proxied URL. For example, access to the query string.