### PR TITLE
proper implementation for forms (FormUrlEncodedContent)

### DIFF
--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -1,7 +1,6 @@
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyModel;
-using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -65,12 +64,8 @@ namespace AspNetCore.Proxy
             if (requestMessage.Content != null)
             {
                 foreach (var header in request.Headers)
-                {
                     if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                    {
                         requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
-                    }
-                }
             }
 
             if (!HttpMethods.IsGet(requestMethod) &&
@@ -80,9 +75,8 @@ namespace AspNetCore.Proxy
             {
                 if (request.HasFormContentType)
                 {
-                    requestMessage.Content = new FormUrlEncodedContent(
-                        request.Form
-                            .Select(x => new KeyValuePair<string, StringValues>(x.Key, x.Value)).ToDictionary(x => x.Key, x => x.Value.ToString()));
+                    var formFields = request.Form.ToDictionary(x => x.Key, x => x.Value.ToString());
+                    requestMessage.Content = new FormUrlEncodedContent(formFields);
                 }
                 else
                 {

--- a/src/Test/UnitTests.cs
+++ b/src/Test/UnitTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
@@ -53,6 +54,21 @@ namespace AspNetCore.Proxy.Tests
 
             var responseString = await response.Content.ReadAsStringAsync();
             Assert.Contains("101", JObject.Parse(responseString).Value<string>("id"));
+        }
+
+        [Fact]
+        public async Task ProxyAttributePostWithFormRequest()
+        {
+            var content = new FormUrlEncodedContent(new Dictionary<string, string> { { "xyz", "123" }, { "abc", "321" } });
+            var response = await _client.PostAsync("api/posts", content);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var json = JObject.Parse(responseString);
+
+            Assert.Contains("101", json.Value<string>("id"));
+            Assert.Equal(json["xyz"], "123");
+            Assert.Equal(json["abc"], "321");
         }
 
         [Fact]


### PR DESCRIPTION
If base request contains Content Type = 'application/x-www-form-urlencoded' then value of those are not copied to then new request