### PR TITLE
including headers for all calls

### DIFF
--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -60,14 +60,6 @@ namespace AspNetCore.Proxy
             var requestMessage = new HttpRequestMessage();
             var requestMethod = request.Method;
 
-            // Copy the request headers.
-            if (requestMessage.Content != null)
-            {
-                foreach (var header in request.Headers)
-                    if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                        requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
-            }
-
             if (!HttpMethods.IsGet(requestMethod) &&
                 !HttpMethods.IsHead(requestMethod) &&
                 !HttpMethods.IsDelete(requestMethod) &&
@@ -82,6 +74,15 @@ namespace AspNetCore.Proxy
                 {
                     var streamContent = new StreamContent(request.Body);
                     requestMessage.Content = streamContent;
+                }
+            }
+
+            // Copy the request headers.
+            foreach (var header in request.Headers)
+            {
+                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
+                {
+                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
                 }
             }
 


### PR DESCRIPTION
Hello

We have a use case where we want to proxy Http GET and DELETE calls that do not have content, but the headers are still used for OAuth bearer token authentication. I feel like proxying headers could be useful even when there's no content in the request. 

I found the library to be very comprehensive, well documented and useful. Thanks for putting it out there.

Thanks