### PR TITLE
proxy headers

### DIFF
--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -61,11 +61,12 @@ namespace AspNetCore.Proxy
             var requestMethod = request.Method;
 
             // Copy the request headers.
-            if (requestMessage.Content != null)
+            foreach (var header in request.Headers)
             {
-                foreach (var header in request.Headers)
-                    if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                        requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
+                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
+                {
+                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
+                }
             }
 
             if (!HttpMethods.IsGet(requestMethod) &&

--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -64,9 +64,7 @@ namespace AspNetCore.Proxy
             foreach (var header in request.Headers)
             {
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                {
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
-                }
             }
 
             if (!HttpMethods.IsGet(requestMethod) &&


### PR DESCRIPTION
Hello

We have a use case where we want to proxy Http GET and DELETE calls that do not have content, but the headers are still used for OAuth bearer token authentication. I feel like proxying headers could be useful even when there's no content in the request.

I found the library to be very comprehensive, well documented and useful. Thanks for putting it out there.

Thanks