### PR TITLE
Fix: Copying headers

### DIFF
--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -60,13 +60,6 @@ namespace AspNetCore.Proxy
             var requestMessage = new HttpRequestMessage();
             var requestMethod = request.Method;
 
-            // Copy the request headers.
-            foreach (var header in request.Headers)
-            {
-                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
-            }
-
             if (!HttpMethods.IsGet(requestMethod) &&
                 !HttpMethods.IsHead(requestMethod) &&
                 !HttpMethods.IsDelete(requestMethod) &&
@@ -82,6 +75,13 @@ namespace AspNetCore.Proxy
                     var streamContent = new StreamContent(request.Body);
                     requestMessage.Content = streamContent;
                 }
+            }
+
+            // Copy the request headers.
+            foreach (var header in request.Headers)
+            {
+                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()) && !request.HasFormContentType)
+                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
             }
 
             requestMessage.Headers.Host = uri.Authority;


### PR DESCRIPTION
Still code must check if FormUrlEncodedContent is used. If `request.HasFormContentType` indicates that this is not form content then we can copy headers also to Content - only then.

Anyway, adding headers to Content is needed at all?