### PR TITLE
Copy request headers after assign content

### DIFF
--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -72,12 +72,8 @@ namespace AspNetCore.Proxy
 
             // Copy the request headers.
             foreach (var header in context.Request.Headers)
-            {
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                {
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
-                }
-            }
 
             requestMessage.Headers.Host = uri.Authority;
             requestMessage.RequestUri = uri;

--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -59,25 +59,17 @@ namespace AspNetCore.Proxy
 
             var requestMessage = new HttpRequestMessage();
             var requestMethod = request.Method;
-            
+
             // Write to request conent, when necessary.
             if (!HttpMethods.IsGet(requestMethod) &&
                 !HttpMethods.IsHead(requestMethod) &&
                 !HttpMethods.IsDelete(requestMethod) &&
                 !HttpMethods.IsTrace(requestMethod))
             {
-                if (request.HasFormContentType)
-                {
-                    var formFields = request.Form.ToDictionary(x => x.Key, x => x.Value.ToString());
-                    requestMessage.Content = new FormUrlEncodedContent(formFields);
-                }
-                else
-                {
-                    var streamContent = new StreamContent(request.Body);
-                    requestMessage.Content = streamContent;
-                }
+                var streamContent = new StreamContent(request.Body);
+                requestMessage.Content = streamContent;
             }
-            
+
             // Copy the request headers.
             foreach (var header in context.Request.Headers)
             {

--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -59,12 +59,7 @@ namespace AspNetCore.Proxy
 
             var requestMessage = new HttpRequestMessage();
             var requestMethod = request.Method;
-
-            // Copy the request headers.
-            foreach (var header in request.Headers)
-                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
-                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
-
+            
             // Write to request conent, when necessary.
             if (!HttpMethods.IsGet(requestMethod) &&
                 !HttpMethods.IsHead(requestMethod) &&
@@ -80,6 +75,15 @@ namespace AspNetCore.Proxy
                 {
                     var streamContent = new StreamContent(request.Body);
                     requestMessage.Content = streamContent;
+                }
+            }
+            
+            // Copy the request headers.
+            foreach (var header in context.Request.Headers)
+            {
+                if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
+                {
+                    requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
                 }
             }
 


### PR DESCRIPTION
Copy request headers before content assign is very bad idea
For example Content-Type is content header and Content is null when we try copy this header
Original https://github.com/aspnet/Proxy/blob/master/src/Microsoft.AspNetCore.Proxy/ProxyAdvancedExtensions.cs#L57