### PR TITLE
Add proxy options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ public class MyController : Controller
             })
             .WithAfterReceive((c, hrm) =>
             {
-                // Alter the conent in  some way before sending back to client.
+                // Alter the content in  some way before sending back to client.
                 var newContent = new StringContent("It's all greek...er, Latin...to me!");
                 hrm.Content = newContent;
             })

--- a/src/Core/AspNetCore.Proxy.csproj
+++ b/src/Core/AspNetCore.Proxy.csproj
@@ -1,15 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Version>2.1.2</Version>
     <AssemblyName>AspNetCore.Proxy</AssemblyName>
     <PackageId>AspNetCore.Proxy</PackageId>
-    <DocumentationFile>bin\AspNetCore.Proxy.xml</DocumentationFile>
+    <Version>3.0.0</Version>
+    <PackageProjectUrl>https://github.com/twitchax/aspnetcore.proxy</PackageProjectUrl>
+
     <TargetFramework>netstandard2.0</TargetFramework>
+    <IsTestProject>false</IsTestProject>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.2.0" />
   </ItemGroup>
+
 </Project>

--- a/src/Core/Helpers.cs
+++ b/src/Core/Helpers.cs
@@ -36,10 +36,12 @@ namespace AspNetCore.Proxy
             {
                 var proxiedRequest = context.CreateProxiedHttpRequest(uri, options?.ShouldAddForwardedHeaders ?? true);
 
-                options?.BeforeSend?.Invoke(context, proxiedRequest);
+                if(options?.BeforeSend != null)
+                    await options.BeforeSend(context, proxiedRequest).ConfigureAwait(false);
                 var proxiedResponse = await context.SendProxiedHttpRequest(proxiedRequest).ConfigureAwait(false);
 
-                options?.AfterReceive?.Invoke(context, proxiedResponse);
+                if(options?.AfterReceive != null)
+                    await options.AfterReceive(context, proxiedResponse).ConfigureAwait(false);
                 await context.WriteProxiedHttpResponse(proxiedResponse).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -52,7 +54,7 @@ namespace AspNetCore.Proxy
                     return;
                 }
 
-                options?.HandleFailure?.Invoke(context, e);
+                await options.HandleFailure(context, e).ConfigureAwait(false);
             }
         }
     }

--- a/src/Core/ProxyOptions.cs
+++ b/src/Core/ProxyOptions.cs
@@ -1,4 +1,3 @@
-
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -23,26 +22,26 @@ namespace AspNetCore.Proxy
         /// <summary>
         /// HandleFailure property.
         /// </summary>
-        /// <value>An <see cref="Action"/> that is invoked once if the proxy operation fails.</value>
-        public Action<HttpContext, Exception> HandleFailure { get; set; }
+        /// <value>A <see cref="Func{HttpContext, Exception, Task}"/> that is invoked once if the proxy operation fails.</value>
+        public Func<HttpContext, Exception, Task> HandleFailure { get; set; }
 
         /// <summary>
         /// BeforeSend property.
         /// </summary>
         /// <value>
-        /// An <see cref="Action"/> that is invoked before the call to the remote endpoint.
+        /// An <see cref="Func{HttpContext, HttpRequestMessage, Task}"/> that is invoked before the call to the remote endpoint.
         /// The <see cref="HttpRequestMessage"/> can be edited before the call.
         /// </value>
-        public Action<HttpContext, HttpRequestMessage> BeforeSend { get; set; }
+        public Func<HttpContext, HttpRequestMessage, Task> BeforeSend { get; set; }
 
         /// <summary>
         /// AfterReceive property.
         /// </summary>
         /// <value>
-        /// An <see cref="Action"/> that is invoked before the response is written to the client.
+        /// An <see cref="Func{HttpContext, HttpResponseMessage, Task}"/> that is invoked before the response is written to the client.
         /// The <see cref="HttpResponseMessage"/> can be edited before the response is written to the client.
         /// </value>
-        public Action<HttpContext, HttpResponseMessage> AfterReceive { get; set; }
+        public Func<HttpContext, HttpResponseMessage, Task> AfterReceive { get; set; }
         
         /// <summary>
         /// The default constructor.
@@ -51,9 +50,9 @@ namespace AspNetCore.Proxy
 
         private ProxyOptions(
             bool shouldAddForwardedHeaders,
-            Action<HttpContext, Exception> handleFailure,
-            Action<HttpContext, HttpRequestMessage> beforeSend,
-            Action<HttpContext, HttpResponseMessage> afterReceive)
+            Func<HttpContext, Exception, Task> handleFailure,
+            Func<HttpContext, HttpRequestMessage, Task> beforeSend,
+            Func<HttpContext, HttpResponseMessage, Task> afterReceive)
         {
             ShouldAddForwardedHeaders = shouldAddForwardedHeaders;
             HandleFailure = handleFailure;
@@ -64,9 +63,9 @@ namespace AspNetCore.Proxy
         private static ProxyOptions CreateFrom(
             ProxyOptions old, 
             bool? shouldAddForwardedHeaders = null,
-            Action<HttpContext, Exception> handleFailure = null,
-            Action<HttpContext, HttpRequestMessage> beforeSend = null,
-            Action<HttpContext, HttpResponseMessage> afterReceive = null)
+            Func<HttpContext, Exception, Task> handleFailure = null,
+            Func<HttpContext, HttpRequestMessage, Task> beforeSend = null,
+            Func<HttpContext, HttpResponseMessage, Task> afterReceive = null)
         {
             return new ProxyOptions(
                 shouldAddForwardedHeaders ?? old.ShouldAddForwardedHeaders,
@@ -93,20 +92,20 @@ namespace AspNetCore.Proxy
         /// </summary>
         /// <param name="handleFailure"></param>
         /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
-        public ProxyOptions WithHandleFailure(Action<HttpContext, Exception> handleFailure) => CreateFrom(this, handleFailure: handleFailure);
+        public ProxyOptions WithHandleFailure(Func<HttpContext, Exception, Task> handleFailure) => CreateFrom(this, handleFailure: handleFailure);
 
         /// <summary>
         /// Sets the <see cref="BeforeSend"/> property to a cloned instance of this <see cref="ProxyOptions"/>.
         /// </summary>
         /// <param name="beforeSend"></param>
         /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
-        public ProxyOptions WithBeforeSend(Action<HttpContext, HttpRequestMessage> beforeSend) => CreateFrom(this, beforeSend: beforeSend);
+        public ProxyOptions WithBeforeSend(Func<HttpContext, HttpRequestMessage, Task> beforeSend) => CreateFrom(this, beforeSend: beforeSend);
 
         /// <summary>
         /// Sets the <see cref="AfterReceive"/> property to a cloned instance of this <see cref="ProxyOptions"/>.
         /// </summary>
         /// <param name="afterReceive"></param>
         /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
-        public ProxyOptions WithAfterReceive(Action<HttpContext, HttpResponseMessage> afterReceive) => CreateFrom(this, afterReceive: afterReceive);
+        public ProxyOptions WithAfterReceive(Func<HttpContext, HttpResponseMessage, Task> afterReceive) => CreateFrom(this, afterReceive: afterReceive);
     }
 }

--- a/src/Core/ProxyOptions.cs
+++ b/src/Core/ProxyOptions.cs
@@ -1,0 +1,112 @@
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace AspNetCore.Proxy
+{
+    /// <summary>
+    /// Defines options that can be set for proxied operations.
+    /// </summary>
+    public class ProxyOptions
+    {
+        /// <summary>
+        /// ShouldAddForwardedHeaders property.
+        /// </summary>
+        /// <value>
+        /// Instructs the proxy operation to add `Forwarded` and `X-Forwarded-*` headers.
+        /// Default behavior is `true`.
+        /// </value>
+        public bool ShouldAddForwardedHeaders { get; set; } = true;
+
+        /// <summary>
+        /// HandleFailure property.
+        /// </summary>
+        /// <value>An <see cref="Action"/> that is invoked once if the proxy operation fails.</value>
+        public Action<HttpContext, Exception> HandleFailure { get; set; }
+
+        /// <summary>
+        /// BeforeSend property.
+        /// </summary>
+        /// <value>
+        /// An <see cref="Action"/> that is invoked before the call to the remote endpoint.
+        /// The <see cref="HttpRequestMessage"/> can be edited before the call.
+        /// </value>
+        public Action<HttpContext, HttpRequestMessage> BeforeSend { get; set; }
+
+        /// <summary>
+        /// AfterReceive property.
+        /// </summary>
+        /// <value>
+        /// An <see cref="Action"/> that is invoked before the response is written to the client.
+        /// The <see cref="HttpResponseMessage"/> can be edited before the response is written to the client.
+        /// </value>
+        public Action<HttpContext, HttpResponseMessage> AfterReceive { get; set; }
+        
+        /// <summary>
+        /// The default constructor.
+        /// </summary>
+        public ProxyOptions() {}
+
+        private ProxyOptions(
+            bool shouldAddForwardedHeaders,
+            Action<HttpContext, Exception> handleFailure,
+            Action<HttpContext, HttpRequestMessage> beforeSend,
+            Action<HttpContext, HttpResponseMessage> afterReceive)
+        {
+            ShouldAddForwardedHeaders = shouldAddForwardedHeaders;
+            HandleFailure = handleFailure;
+            BeforeSend = beforeSend;
+            AfterReceive = afterReceive;
+        }
+
+        private static ProxyOptions CreateFrom(
+            ProxyOptions old, 
+            bool? shouldAddForwardedHeaders = null,
+            Action<HttpContext, Exception> handleFailure = null,
+            Action<HttpContext, HttpRequestMessage> beforeSend = null,
+            Action<HttpContext, HttpResponseMessage> afterReceive = null)
+        {
+            return new ProxyOptions(
+                shouldAddForwardedHeaders ?? old.ShouldAddForwardedHeaders,
+                handleFailure ?? old.HandleFailure,
+                beforeSend ?? old.BeforeSend,
+                afterReceive ?? old.AfterReceive);
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="ProxyOptions"/> for building purposes.
+        /// </summary>
+        /// <returns>A new, default, instance of <see cref="ProxyOptions"/>.</returns>
+        public static ProxyOptions Instance => new ProxyOptions();
+
+        /// <summary>
+        /// Sets the <see cref="ShouldAddForwardedHeaders"/> property to a cloned instance of this <see cref="ProxyOptions"/>.
+        /// </summary>
+        /// <param name="shouldAddForwardedHeaders"></param>
+        /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
+        public ProxyOptions WithShouldAddForwardedHeaders(bool shouldAddForwardedHeaders) => CreateFrom(this, shouldAddForwardedHeaders: shouldAddForwardedHeaders);
+
+        /// <summary>
+        /// Sets the <see cref="HandleFailure"/> property to a cloned instance of this <see cref="ProxyOptions"/>.
+        /// </summary>
+        /// <param name="handleFailure"></param>
+        /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
+        public ProxyOptions WithHandleFailure(Action<HttpContext, Exception> handleFailure) => CreateFrom(this, handleFailure: handleFailure);
+
+        /// <summary>
+        /// Sets the <see cref="BeforeSend"/> property to a cloned instance of this <see cref="ProxyOptions"/>.
+        /// </summary>
+        /// <param name="beforeSend"></param>
+        /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
+        public ProxyOptions WithBeforeSend(Action<HttpContext, HttpRequestMessage> beforeSend) => CreateFrom(this, beforeSend: beforeSend);
+
+        /// <summary>
+        /// Sets the <see cref="AfterReceive"/> property to a cloned instance of this <see cref="ProxyOptions"/>.
+        /// </summary>
+        /// <param name="afterReceive"></param>
+        /// <returns>A new instance of <see cref="ProxyOptions"/> with the new value for the property.</returns>
+        public ProxyOptions WithAfterReceive(Action<HttpContext, HttpResponseMessage> afterReceive) => CreateFrom(this, afterReceive: afterReceive);
+    }
+}

--- a/src/Test/UnitTests.cs
+++ b/src/Test/UnitTests.cs
@@ -324,6 +324,7 @@ namespace AspNetCore.Proxy.Tests
                 .WithBeforeSend((c, hrm) =>
                 {
                     hrm.RequestUri = new Uri("https://jsonplaceholder.typicode.com/posts/2");
+                    return Task.CompletedTask;
                 });
 
             return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
@@ -337,6 +338,7 @@ namespace AspNetCore.Proxy.Tests
                 {
                     var newContent = new StringContent("It's all greek...er, Latin...to me!");
                     hrm.Content = newContent;
+                    return Task.CompletedTask;
                 });
 
             return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
@@ -353,6 +355,8 @@ namespace AspNetCore.Proxy.Tests
                         var newContent = new StringContent("I tried to proxy, but I chose a bad address, and it is not found.");
                         hrm.Content = newContent;
                     }
+
+                    return Task.CompletedTask;
                 });
 
             return this.ProxyAsync($"https://jsonplaceholder.typicode.com/badpath/{postId}", options);
@@ -365,6 +369,7 @@ namespace AspNetCore.Proxy.Tests
             {
                 var a = 0;
                 var b = 1 / a;
+                return Task.CompletedTask;
             });
             return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
         }
@@ -377,11 +382,12 @@ namespace AspNetCore.Proxy.Tests
                 {
                     var a = 0;
                     var b = 1 / a;
+                    return Task.CompletedTask;
                 })
                 .WithHandleFailure((c, e) =>
                 {
                     c.Response.StatusCode = 403;
-                    c.Response.WriteAsync("Things borked.");
+                    return c.Response.WriteAsync("Things borked.");
                 });
 
             return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);

--- a/src/Test/UnitTests.cs
+++ b/src/Test/UnitTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
@@ -11,7 +10,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Linq;
 using Xunit;
@@ -30,7 +28,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyAttributeToTask()
+        public async Task CanProxyAttributeToTask()
         {
             var response = await _client.GetAsync("api/posts/totask/1");
             response.EnsureSuccessStatusCode();
@@ -40,7 +38,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyAttributeToString()
+        public async Task CanProxyAttributeToString()
         {
             var response = await _client.GetAsync("api/posts/tostring/1");
             response.EnsureSuccessStatusCode();
@@ -50,7 +48,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyAttributePostRequest()
+        public async Task CanProxyAttributePostRequest()
         {
             var content = new StringContent("{\"title\": \"foo\", \"body\": \"bar\", \"userId\": 1}", Encoding.UTF8, "application/json");
             var response = await _client.PostAsync("api/posts", content);
@@ -62,7 +60,7 @@ namespace AspNetCore.Proxy.Tests
 
 
         [Fact]
-        public async Task ProxyContentHeadersPostRequest()
+        public async Task CanProxyContentHeadersPostRequest()
         {
             var content = "hello world";
             var contentType = "application/xcustom";
@@ -81,7 +79,7 @@ namespace AspNetCore.Proxy.Tests
 
 
         [Fact]
-        public async Task ProxyAttributePostWithFormRequest()
+        public async Task CanProxyAttributePostWithFormRequest()
         {
             var content = new FormUrlEncodedContent(new Dictionary<string, string> { { "xyz", "123" }, { "abc", "321" } });
             var response = await _client.PostAsync("api/posts", content);
@@ -96,7 +94,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyAttributeCatchAll()
+        public async Task CanProxyAttributeCatchAll()
         {
             var response = await _client.GetAsync("api/catchall/posts/1");
             response.EnsureSuccessStatusCode();
@@ -106,7 +104,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyMiddlewareWithContextAndArgsToTask()
+        public async Task CanProxyMiddlewareWithContextAndArgsToTask()
         {
             var response = await _client.GetAsync("api/comments/contextandargstotask/1");
             response.EnsureSuccessStatusCode();
@@ -116,7 +114,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyMiddlewareWithArgsToTask()
+        public async Task CanProxyMiddlewareWithArgsToTask()
         {
             var response = await _client.GetAsync("api/comments/argstotask/1");
             response.EnsureSuccessStatusCode();
@@ -126,7 +124,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyMiddlewareWithEmptyToTask()
+        public async Task CanProxyMiddlewareWithEmptyToTask()
         {
             var response = await _client.GetAsync("api/comments/emptytotask");
             response.EnsureSuccessStatusCode();
@@ -136,7 +134,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyMiddlewareWithContextAndArgsToString()
+        public async Task CanProxyMiddlewareWithContextAndArgsToString()
         {
             var response = await _client.GetAsync("api/comments/contextandargstostring/1");
             response.EnsureSuccessStatusCode();
@@ -146,7 +144,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyMiddlewareWithArgsToString()
+        public async Task CanProxyMiddlewareWithArgsToString()
         {
             var response = await _client.GetAsync("api/comments/argstostring/1");
             response.EnsureSuccessStatusCode();
@@ -156,7 +154,7 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyMiddlewareWithEmptyToString()
+        public async Task CanProxyMiddlewareWithEmptyToString()
         {
             var response = await _client.GetAsync("api/comments/emptytostring");
             response.EnsureSuccessStatusCode();
@@ -166,13 +164,47 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
-        public async Task ProxyController()
+        public async Task CanProxyWithController()
         {
             var response = await _client.GetAsync("api/controller/posts/1");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
             Assert.Contains("sunt aut facere repellat provident occaecati excepturi optio reprehenderit", JObject.Parse(responseString).Value<string>("title"));
+        }
+
+        [Fact]
+        public async Task CanModifyRequest()
+        {
+            var response = await _client.GetAsync("api/controller/customrequest/1");
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            Assert.Contains("qui est esse", JObject.Parse(responseString).Value<string>("title"));
+        }
+
+        [Fact]
+        public async Task CanModifyResponse()
+        {
+            var response = await _client.GetAsync("api/controller/customresponse/1");
+            response.EnsureSuccessStatusCode();
+            
+            Assert.Equal("It's all greek...er, Latin...to me!", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task CanGetGeneric502OnFailure()
+        {
+            var response = await _client.GetAsync("api/controller/fail/1");
+            Assert.Equal("BadGateway", response.StatusCode.ToString());
+        }
+
+        [Fact]
+        public async Task CanGetCustomFailure()
+        {
+            var response = await _client.GetAsync("api/controller/customfail/1");
+            Assert.Equal("Forbidden", response.StatusCode.ToString());
+            Assert.Equal("Things borked.", await response.Content.ReadAsStringAsync());
         }
     }
 
@@ -274,6 +306,60 @@ namespace AspNetCore.Proxy.Tests
         public Task GetPosts(int postId)
         {
             return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}");
+        }
+
+        [Route("api/controller/customrequest/{postId}")]
+        public Task GetWithCustomRequest(int postId)
+        {
+            var options = ProxyOptions.Instance
+                .WithBeforeSend((c, hrm) =>
+                {
+                    hrm.RequestUri = new Uri("https://jsonplaceholder.typicode.com/posts/2");
+                });
+
+            return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
+        }
+
+        [Route("api/controller/customresponse/{postId}")]
+        public Task GetWithCustomResponse(int postId)
+        {
+            var options = ProxyOptions.Instance
+                .WithAfterReceive((c, hrm) =>
+                {
+                    var newContent = new StringContent("It's all greek...er, Latin...to me!");
+                    hrm.Content = newContent;
+                });
+
+            return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
+        }
+
+        [Route("api/controller/fail/{postId}")]
+        public Task GetWithGenericFail(int postId)
+        {
+            var options = ProxyOptions.Instance.WithBeforeSend((c, hrm) =>
+            {
+                var a = 0;
+                var b = 1 / a;
+            });
+            return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
+        }
+
+        [Route("api/controller/customfail/{postId}")]
+        public Task GetWithCustomFail(int postId)
+        {
+            var options = ProxyOptions.Instance
+                .WithBeforeSend((c, hrm) =>
+                {
+                    var a = 0;
+                    var b = 1 / a;
+                })
+                .WithHandleFailure((c, e) =>
+                {
+                    c.Response.StatusCode = 403;
+                    c.Response.WriteAsync("Things borked.");
+                });
+
+            return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
         }
     }
 }


### PR DESCRIPTION
Allow the developer to set proxy options.

```csharp
public class MyController : Controller
{
    [Route("api/posts/{postId}")]
    public Task GetPosts(int postId)
    {
        var options = ProxyOptions.Instance
            .WithShouldAddForwardedHeaders(false)
            .WithBeforeSend((c, hrm) =>
            {
                // Set something that is needed for the downstream endpoint.
                hrm.Headers.Authorization = new AuthenticationHeaderValue("Basic");
            })
            .WithAfterReceive((c, hrm) =>
            {
                // Alter the conent in  some way before sending back to client.
                var newContent = new StringContent("It's all greek...er, Latin...to me!");
                hrm.Content = newContent;
            })
            .WithHandleFailure((c, e) =>
            {
                // Return a custom error response.
                c.Response.StatusCode = 403;
                c.Response.WriteAsync("Things borked.");
            });

        return this.ProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}");
    }
}
```

Also, adds `X-Forwarded-*` and `Forwarded` headers.