### PR TITLE
Add support for query parameters in RunProxy()

### DIFF
--- a/src/Core/Extensions/Basic.cs
+++ b/src/Core/Extensions/Basic.cs
@@ -240,7 +240,7 @@ namespace AspNetCore.Proxy.Extensions
             return async (context, args) =>
             {
                 var endpoint = await GetEndpointFromComputerAsync(context, endpointComputer).ConfigureAwait(false);
-                return $"{endpoint}{context.Request.Path}";
+                return $"{endpoint}{context.Request.Path}{context.Request.QueryString}";
             };
         }
 

--- a/src/Test/Extensions.cs
+++ b/src/Test/Extensions.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Extensions;
 
 namespace AspNetCore.Proxy.Tests
 {
@@ -63,7 +64,8 @@ namespace AspNetCore.Proxy.Tests
         internal static async Task HttpBoomerang(this HttpContext context)
         {
             var message = await new StreamReader(context.Request.Body).ReadToEndAsync();
-            await context.Response.WriteAsync($"[{message}]");
+            var uri = context.Request.GetDisplayUrl();
+            await context.Response.WriteAsync($"({uri})[{message}]");
         }
     }
 }

--- a/src/Test/RunProxy/RunProxyIntegrationTests.cs
+++ b/src/Test/RunProxy/RunProxyIntegrationTests.cs
@@ -70,7 +70,7 @@ namespace AspNetCore.Proxy.Tests
 
             // HTTP test.
             var response = await _httpClient.PostAsync("http://localhost:5003/at/some/path", new StringContent(send1));
-            Assert.Equal(expected1, await response.Content.ReadAsStringAsync());
+            Assert.EndsWith(expected1, await response.Content.ReadAsStringAsync());
         }
 
         [Fact]
@@ -80,6 +80,16 @@ namespace AspNetCore.Proxy.Tests
             var expected1 = $"[{send1}]";
 
             var response = await _httpClient.PostAsync("http://localhost:5007/at/some/other/path", new StringContent(send1));
+            Assert.EndsWith(expected1, await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task CanAppendQueryParameters()
+        {
+            var send1 = "TESTWITHQUERY";
+            var expected1 = $"(http://localhost:5004/at/some/other/path?with=query&parameters=true)[{send1}]";
+
+            var response = await _httpClient.PostAsync("http://localhost:5007/at/some/other/path?with=query&parameters=true", new StringContent(send1));
             Assert.Equal(expected1, await response.Content.ReadAsStringAsync());
         }
 


### PR DESCRIPTION
I've been using this library as a simple proxy using the `RunProxy` extension, and noticed it doesn't forward the query string from the original request on to the target. 

This is easy enough to work around in `BeforeSend` with something like:
```
BeforeSend = (context, request) =>
  {
    request.RequestUri = new Uri(request.RequestUri.ToString() + context.Request.QueryString);
    return Task.CompletedTask;
  },
```
But I thought it would be nice if this just worked out of the box! Is there a reason for not forwarding the query string that i'm missing? If not, this PR adds that functionality.

I've worked against your v4 branch, which I hope was the right thing to do - and had to tweak the test HttpBoomerang a little so that I can assert on the uri as well as content.

All the unit tests pass but I have a bunch of failing integration tests when running locally, i've got a feeling that the third party service you use for those is at fault rather than anything i've changed!