### PR TITLE
Add failing test for catchall proxying form data.

### DIFF
--- a/src/Test/Http/HttpIntegrationTests.cs
+++ b/src/Test/Http/HttpIntegrationTests.cs
@@ -68,6 +68,21 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
+        public async Task CanProxyControllerCatchAllPostWithFormRequest()
+        {
+            var content = new FormUrlEncodedContent(new Dictionary<string, string> { { "xyz", "123" }, { "abc", "321" } });
+            var response = await _client.PostAsync("api/catchall/posts", content);
+            response.EnsureSuccessStatusCode();
+
+            var responseString = await response.Content.ReadAsStringAsync();
+            var json = JObject.Parse(responseString);
+
+            Assert.Contains("101", json.Value<string>("id"));
+            Assert.Equal("123", json["xyz"]);
+            Assert.Equal("321", json["abc"]);
+        }
+
+        [Fact]
         public async Task CanProxyControllerCatchAll()
         {
             var response = await _client.GetAsync("api/catchall/posts/1");


### PR DESCRIPTION
As requested, this is a failing test for issue #57.

This is simply a copy of `CanProxyControllerPostWithFormRequest()` changed to send to `"api/catchall/posts"`.

In this test (unlike what I mentioned in that issue) it does not hang and eventually timeout, but that is due to the server it is proxying to gracefully handling the empty request body. The problem can still be seen via something like Wireshark checking the request that actually gets sent, as it is empty. And as the request sent is empty, the response data doesn't contain the parameters we tried to send, and the test fails.