### PR TITLE
Proxy forms without relying on the request body

### DIFF
--- a/src/Core/Extensions/Http.cs
+++ b/src/Core/Extensions/Http.cs
@@ -81,11 +81,14 @@ namespace AspNetCore.Proxy
                 !HttpMethods.IsDelete(requestMethod) &&
                 !HttpMethods.IsTrace(requestMethod))
             {
-                requestMessage.Content = new StreamContent(request.Body);
+                if (request.HasFormContentType)
+                    requestMessage.Content = request.Form.ToStreamContent();
+                else
+                    requestMessage.Content = new StreamContent(request.Body);
             }
 
             // Copy the request headers.
-            foreach (var header in context.Request.Headers)
+            foreach (var header in request.Headers)
             {
                 if (!requestMessage.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray()))
                     requestMessage.Content?.Headers.TryAddWithoutValidation(header.Key, header.Value.ToArray());
@@ -98,7 +101,7 @@ namespace AspNetCore.Proxy
             // Set destination and method.
             requestMessage.Headers.Host = uri.Authority;
             requestMessage.RequestUri = uri;
-            requestMessage.Method = new HttpMethod(request.Method);
+            requestMessage.Method = new HttpMethod(requestMethod);
 
             return requestMessage;
         }

--- a/src/Core/Helpers/Helpers.cs
+++ b/src/Core/Helpers/Helpers.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Primitives;
 
 namespace AspNetCore.Proxy
 {
@@ -72,9 +73,34 @@ namespace AspNetCore.Proxy
             return s.Substring(0, s.Length - count);
         }
 
-        internal static StreamContent ToStreamContent(this IFormCollection collection)
+        internal static HttpContent ToHttpContent(this IFormCollection collection, string contentType)
         {
-            return new StreamContent(new MemoryStream(HttpUtility.UrlDecodeToBytes(string.Join("&", collection.Select(f => $"{f.Key}={f.Value}")))));
+            if (string.IsNullOrWhiteSpace(contentType) || contentType.Equals("application/x-www-form-urlencoded", StringComparison.OrdinalIgnoreCase))
+                return new FormUrlEncodedContent(collection.SelectMany(formItemList => formItemList.Value.Select(value => new KeyValuePair<string, string>(formItemList.Key, value))));
+
+            if (!contentType.StartsWith("multipart/form-data;", StringComparison.OrdinalIgnoreCase))
+                throw new Exception($"Unknown form content type \"{contentType[0]}\"");
+
+            const string boundary = "boundary=";
+            var boundaryIndex = contentType.IndexOf(boundary, StringComparison.OrdinalIgnoreCase);
+            if (boundaryIndex < 0)
+                throw new Exception("Could not find multipart boundary");
+            var delimiter = contentType.Substring(boundaryIndex + boundary.Length);
+
+            var multipart = new MultipartFormDataContent(delimiter);
+            foreach (var formVal in collection)
+            {
+                foreach (var value in formVal.Value)
+                    multipart.Add(new StringContent(value), formVal.Key);
+            }
+            foreach (var file in collection.Files)
+            {
+                var content = new StreamContent(file.OpenReadStream());
+                foreach (var header in file.Headers)
+                    content.Headers.TryAddWithoutValidation(header.Key, (IEnumerable<string>)header.Value);
+                multipart.Add(content, file.Name, file.FileName);
+            }
+            return multipart;
         }
     }
 }

--- a/src/Core/Helpers/Helpers.cs
+++ b/src/Core/Helpers/Helpers.cs
@@ -1,6 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Http;
 
 namespace AspNetCore.Proxy
@@ -66,6 +70,11 @@ namespace AspNetCore.Proxy
             }
 
             return s.Substring(0, s.Length - count);
+        }
+
+        internal static StreamContent ToStreamContent(this IFormCollection collection)
+        {
+            return new StreamContent(new MemoryStream(HttpUtility.UrlDecodeToBytes(string.Join("&", collection.Select(f => $"{f.Key}={f.Value}")))));
         }
     }
 }

--- a/src/Core/Helpers/Helpers.cs
+++ b/src/Core/Helpers/Helpers.cs
@@ -85,7 +85,7 @@ namespace AspNetCore.Proxy
             var boundaryIndex = contentType.IndexOf(boundary, StringComparison.OrdinalIgnoreCase);
             if (boundaryIndex < 0)
                 throw new Exception("Could not find multipart boundary");
-            var delimiter = contentType.Substring(boundaryIndex + boundary.Length);
+            var delimiter = contentType.Substring(boundaryIndex + boundary.Length).Trim('"');
 
             var multipart = new MultipartFormDataContent(delimiter);
             foreach (var formVal in collection)

--- a/src/Test/Http/HttpHelpers.cs
+++ b/src/Test/Http/HttpHelpers.cs
@@ -81,6 +81,12 @@ namespace AspNetCore.Proxy.Tests
             return this.HttpProxyAsync("https://jsonplaceholder.typicode.com/posts");
         }
 
+        [Route("api/multipart")]
+        public Task ProxyPostMultipartRequest()
+        {
+            return this.HttpProxyAsync("https://httpbin.org/post");
+        }
+
         [Route("api/catchall/{**rest}")]
         public Task ProxyCatchAll(string rest)
         {


### PR DESCRIPTION
Fixes #57 and replaced #60.

For requests with a form content type .Net seems to consume the request body if model binding / method parameters are present on a controller, even if they should be using route or query string values. Avoid the problem by re-creating the request body from the form data.