### PR TITLE
update packaging for .net 5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Setup .NET Environment.
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1.101'
+        dotnet-version: '5.0.202'
     - name: Build and run tests.
       run: dotnet test --collect:"XPlat Code Coverage"
     - name: Make artifacts directory.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,14 @@ jobs:
     steps:
     - name: Checkout!
       uses: actions/checkout@v1
-    - name: Setup .NET Environment.
+    - name: Setup .NET Core 3.1
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '5.0.202'
+        dotnet-version: '3.1'
+    - name: Setup .NET 5
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0'
     - name: Build and run tests.
       run: dotnet test --collect:"XPlat Code Coverage"
     - name: Make artifacts directory.

--- a/src/Core/AspNetCore.Proxy.csproj
+++ b/src/Core/AspNetCore.Proxy.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <AssemblyName>AspNetCore.Proxy</AssemblyName>
@@ -6,17 +6,16 @@
     <Version>4.1.0</Version>
     <PackageProjectUrl>https://github.com/twitchax/aspnetcore.proxy</PackageProjectUrl>
 
-    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0;net5.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsTestProject>false</IsTestProject>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <IsPackable>true</IsPackable>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="2.1.0" />

--- a/src/Test/AspNetCore.Proxy.Tests.csproj
+++ b/src/Test/AspNetCore.Proxy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1;net5.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/src/Test/AspNetCore.Proxy.Tests.csproj
+++ b/src/Test/AspNetCore.Proxy.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1;net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>


### PR DESCRIPTION
This MR updates the packaging of this project (which is awesome, thanks by the way!) to support .net 5.  There are no breaking API changes, it just means that we don't hit the old `netstandard2.0` pathway which drags in Aspnetcore dependencies that aren't the framework reference.