### PR TITLE
Fix buffer handling for large WebSocket messages

### DIFF
--- a/src/Test/Http/HttpHelpers.cs
+++ b/src/Test/Http/HttpHelpers.cs
@@ -6,9 +6,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
-using AspNetCore.Proxy;
 using AspNetCore.Proxy.Options;
 using System.Diagnostics.CodeAnalysis;
 

--- a/src/Test/RunProxy/RunProxyHelpers.cs
+++ b/src/Test/RunProxy/RunProxyHelpers.cs
@@ -1,12 +1,9 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using AspNetCore.Proxy;
 
 namespace AspNetCore.Proxy.Tests
 {

--- a/src/Test/Unit/Endpoints.cs
+++ b/src/Test/Unit/Endpoints.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading.Tasks;
 using AspNetCore.Proxy.Endpoints;
 using Xunit;
 

--- a/src/Test/Ws/WsHelpers.cs
+++ b/src/Test/Ws/WsHelpers.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
@@ -6,7 +7,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using AspNetCore.Proxy;
 using Microsoft.AspNetCore.Http;
 
 namespace AspNetCore.Proxy.Tests
@@ -77,6 +77,15 @@ namespace AspNetCore.Proxy.Tests
                 .Build().RunAsync(token);
 
             return Task.WhenAll(proxiedServerTask, proxyServerTask);
+        }
+
+        internal static string GetRandomBase64String(int sizeInKb)
+        {
+            var rnd = new Random();
+            var b = new byte[sizeInKb * 1024];
+            rnd.NextBytes(b);
+
+            return Convert.ToBase64String(b);
         }
     }
 }


### PR DESCRIPTION
The original code seems to have issues when proxying large messages. Increasing the buffer size using `WithBufferSize()` helps, but it also significantly increases memory usage. This PR uses a dynamic-sized buffer using a `MemoyStream`.

`﻿AspNetCore.Proxy.Tests` running fine and also tested with large JSON messages manually. 