### PR TITLE
Proxy Http Reason Phrase to Avoid Unconscious Incompatibilities.

### DIFF
--- a/src/Core/Extensions/Http.cs
+++ b/src/Core/Extensions/Http.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using AspNetCore.Proxy.Builders;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace AspNetCore.Proxy
@@ -124,6 +125,13 @@ namespace AspNetCore.Proxy
             var response = context.Response;
 
             response.StatusCode = (int)responseMessage.StatusCode;
+
+            var httpResponseFeature = context.Features.Get<IHttpResponseFeature>();
+            if (httpResponseFeature != null)
+            {
+                httpResponseFeature.ReasonPhrase = responseMessage.ReasonPhrase;
+            }
+
             foreach (var header in responseMessage.Headers)
             {
                 response.Headers[header.Key] = header.Value.ToArray();

--- a/src/Test/Http/HttpHelpers.cs
+++ b/src/Test/Http/HttpHelpers.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using AspNetCore.Proxy.Options;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.AspNetCore.Http.Features;
 
 [assembly: SuppressMessage("Readability", "RCS1090", Justification = "Not a library, so no need for `ConfigureAwait`.")]
 
@@ -142,6 +143,31 @@ namespace AspNetCore.Proxy.Tests
 
             return this.HttpProxyAsync($"https://jsonplaceholder.typicode.com/posts/{postId}", options);
         }
+
+        [Route("api/controller/customreasonphase")]
+        public void GetWithCustomReasonPhase(int postId)
+        {
+        }
+
+        [Route("api/controller/customreasonphase/proxy")]
+        public Task GetWithCustomReasonPhase()
+        {
+            var options = HttpProxyOptionsBuilder.Instance.WithIntercept(
+                async (ctx) =>
+                {
+                    var httpResponseFeature = ctx.Features.Get<IHttpResponseFeature>();
+                    if (httpResponseFeature != null)
+                    {
+                        httpResponseFeature.ReasonPhrase = "I am dummy!";
+                    }
+
+                    return true;
+
+                }).Build();
+                
+            return this.HttpProxyAsync("https://postman-echo.com/post", options);
+        }
+
 
         [Route("api/controller/timeoutclient/{postId}")]
         public Task GetWithTimeoutClient(int postId)

--- a/src/Test/Http/HttpIntegrationTests.cs
+++ b/src/Test/Http/HttpIntegrationTests.cs
@@ -207,6 +207,15 @@ namespace AspNetCore.Proxy.Tests
         }
 
         [Fact]
+        public async Task CanProxyReasonPhase()
+        {
+            var response = await _client.GetAsync("api/controller/customreasonphase/proxy");
+
+            response.EnsureSuccessStatusCode();
+            Assert.Equal("I am dummy!", response.ReasonPhrase);
+        }
+
+        [Fact]
         public async Task CanProxyConcurrentCalls()
         {
             var calls = Enumerable.Range(1, 100).Select(i => _client.GetAsync($"api/controller/posts/{i}"));


### PR DESCRIPTION
Some backend services (e.g., Azure Relay) are customizing HTTP reason phrases. This should be considered as misuse of the HTTP protocol but that info may need to be kept at the proxying time to keep the integrity of the origin messages.

An example response: 
```
401 MissingToken: Relay security token is required. TrackingId:988e8147-c5ed-473c-a679-fb2c0d400ee4_G11, SystemTracker:hdirelay-uswe-d4c1893d-0.servicebus.windows.net:a21a0c87558b411bb098f8a8c7cad92a, Timestamp:2023-03-07T03:52:29
```