### PR TITLE
Fix for NullReferenceException when GetService<IHttpClientFactory>() fails

### DIFF
--- a/src/Core/Extensions/Http.cs
+++ b/src/Core/Extensions/Http.cs
@@ -23,6 +23,10 @@ namespace AspNetCore.Proxy
                 var httpClient = context.RequestServices
                     .GetService<IHttpClientFactory>()
                     .CreateClient(options?.HttpClientName ?? Helpers.HttpProxyClientName);
+                var clientFactory = context.RequestServices.GetService<IHttpClientFactory>()
+                ?? throw new InvalidOperationException("IHttpClientFactory not registered. You need to add builder.Services.AddHttpClient(); during startup");
+
+                var httpClient = clientFactory.CreateClient(options?.HttpClientName ?? Helpers.HttpProxyClientName);
 
                 // If `true`, this proxy call has been intercepted.
                 if(options?.Intercept != null && await options.Intercept(context).ConfigureAwait(false))

--- a/src/Core/Extensions/Http.cs
+++ b/src/Core/Extensions/Http.cs
@@ -20,9 +20,6 @@ namespace AspNetCore.Proxy
 
             try
             {
-                var httpClient = context.RequestServices
-                    .GetService<IHttpClientFactory>()
-                    .CreateClient(options?.HttpClientName ?? Helpers.HttpProxyClientName);
                 var clientFactory = context.RequestServices.GetService<IHttpClientFactory>()
                 ?? throw new InvalidOperationException("IHttpClientFactory not registered. You need to add builder.Services.AddHttpClient(); during startup");
 


### PR DESCRIPTION
Fix for this [#98](https://github.com/twitchax/AspNetCore.Proxy/issues/98)

It's 2:20 AM
I was stuck on this error for too long...
To whoever didn't fix it the first time - fuck you.
To the creator of AspNetCore.Proxy - thank you.